### PR TITLE
Calculate containers usage based on snapshots

### DIFF
--- a/pkg/pillar/cas/cas.go
+++ b/pkg/pillar/cas/cas.go
@@ -88,6 +88,12 @@ type CAS interface {
 	//MountSnapshot: mounts the snapshot on the given target path
 	//Arg 'snapshotID' should be of format <algo>:<hash> (currently supporting only sha256:<hash>).
 	MountSnapshot(snapshotID, targetPath string) error
+	// SnapshotUsage returns current usage of snapshot in bytes
+	// We create snapshots for every layer of image and one active snapshot on top of them
+	// which presents the writable layer to store modified files
+	// If parents defined also adds usage of all parents of provided snapshot,
+	// not only the top active one
+	SnapshotUsage(snapshotID string, parents bool) (int64, error)
 	//ListSnapshots: returns a list of snapshotIDs where each entry is of format <algo>:<hash> (currently supporting only sha256:<hash>).
 	ListSnapshots() ([]string, error)
 	//ListSnapshots: removes a snapshot matching the given 'snapshotID'.

--- a/pkg/pillar/cmd/volumemgr/handlediskmetrics.go
+++ b/pkg/pillar/cmd/volumemgr/handlediskmetrics.go
@@ -258,7 +258,7 @@ func createOrUpdateAppDiskMetrics(ctx *volumemgrContext, volumeStatus *types.Vol
 		// Nothing we can do? XXX can we retrieve size from CAS?
 		return nil
 	}
-	actualSize, maxSize, diskType, dirtyFlag, err := utils.GetVolumeSize(log, volumeStatus.FileLocation)
+	actualSize, maxSize, diskType, dirtyFlag, err := utils.GetVolumeSize(log, ctx.casClient, volumeStatus.FileLocation)
 	if err != nil {
 		err = fmt.Errorf("createOrUpdateAppDiskMetrics(%s, %s): exception while getting volume size. %s",
 			volumeStatus.VolumeID, volumeStatus.FileLocation, err)

--- a/pkg/pillar/cmd/volumemgr/handlevolume.go
+++ b/pkg/pillar/cmd/volumemgr/handlevolume.go
@@ -200,7 +200,7 @@ func handleDeferredVolumeCreate(ctx *volumemgrContext, key string, config *types
 		status.Progress = 100
 		status.SubState = types.VolumeSubStateCreated
 		status.CreateTime = time.Now()
-		actualSize, maxSize, _, _, err := utils.GetVolumeSize(log, status.FileLocation)
+		actualSize, maxSize, _, _, err := utils.GetVolumeSize(log, ctx.casClient, status.FileLocation)
 		if err != nil {
 			log.Error(err)
 		} else {

--- a/pkg/pillar/cmd/volumemgr/updatestatus.go
+++ b/pkg/pillar/cmd/volumemgr/updatestatus.go
@@ -700,7 +700,7 @@ func doUpdateVol(ctx *volumemgrContext, status *types.VolumeStatus) (bool, bool)
 		// Work is done
 		DeleteWorkCreate(ctx, status)
 		if status.MaxVolSize == 0 {
-			_, maxVolSize, _, _, err := utils.GetVolumeSize(log, status.FileLocation)
+			_, maxVolSize, _, _, err := utils.GetVolumeSize(log, ctx.casClient, status.FileLocation)
 			if err != nil {
 				log.Error(err)
 			} else if maxVolSize != status.MaxVolSize {

--- a/pkg/pillar/containerd/containerd.go
+++ b/pkg/pillar/containerd/containerd.go
@@ -335,6 +335,19 @@ func (client *Client) CtrListSnapshotInfo(ctx context.Context) ([]snapshots.Info
 	return snapshotInfoList, nil
 }
 
+// CtrGetSnapshotUsage returns snapshot's usage for snapshotID present in containerd's snapshot store
+func (client *Client) CtrGetSnapshotUsage(ctx context.Context, snapshotID string) (*snapshots.Usage, error) {
+	if err := client.verifyCtr(ctx, true); err != nil {
+		return nil, fmt.Errorf("CtrListSnapshotInfo: exception while verifying ctrd client: %s", err.Error())
+	}
+	snapshotter := client.ctrdClient.SnapshotService(defaultSnapshotter)
+	su, err := snapshotter.Usage(ctx, snapshotID)
+	if err != nil {
+		return nil, fmt.Errorf("CtrGetSnapshotUsage: Exception while fetching snapshot usage: %s", err.Error())
+	}
+	return &su, nil
+}
+
 //CtrRemoveSnapshot removed snapshot by ID from containerd
 func (client *Client) CtrRemoveSnapshot(ctx context.Context, snapshotID string) error {
 	if err := client.verifyCtr(ctx, true); err != nil {

--- a/pkg/pillar/utils/volumeutils.go
+++ b/pkg/pillar/utils/volumeutils.go
@@ -9,39 +9,50 @@ import (
 	"os"
 
 	"github.com/lf-edge/eve/pkg/pillar/base"
+	"github.com/lf-edge/eve/pkg/pillar/cas"
+	"github.com/lf-edge/eve/pkg/pillar/containerd"
 	"github.com/lf-edge/eve/pkg/pillar/diskmetrics"
 	"github.com/lf-edge/eve/pkg/pillar/zfs"
 )
 
 // GetVolumeSize returns the actual and maximum size of the volume
 // plus a DiskType and a DirtyFlag
-func GetVolumeSize(log *base.LogObject, name string) (uint64, uint64, string, bool, error) {
-	info, err := os.Stat(name)
+func GetVolumeSize(log *base.LogObject, casClient cas.CAS, fileLocation string) (uint64, uint64, string, bool, error) {
+	info, err := os.Stat(fileLocation)
 	if err != nil {
-		errStr := fmt.Sprintf("GetVolumeSize failed for %s: %v",
-			name, err)
-		return 0, 0, "", false, errors.New(errStr)
+		return 0, 0, "", false, fmt.Errorf("GetVolumeSize failed for %s: %v",
+			fileLocation, err)
 	}
+	// Assume this is a container
 	if info.IsDir() {
-		// Assume this is a container
-		size, err := diskmetrics.SizeFromDir(log, name)
+		var size uint64
+		snapshotID := containerd.GetSnapshotID(fileLocation)
+		su, err := casClient.SnapshotUsage(snapshotID, true)
+		if err == nil {
+			size = uint64(su)
+		} else {
+			// we did not create snapshot yet
+			log.Warnf("GetVolumeSize: Failed get snapshot usage: %s for %s. Error %s",
+				snapshotID, fileLocation, err)
+			size, err = diskmetrics.SizeFromDir(log, fileLocation)
+		}
 		return size, size, "CONTAINER", false, err
 	}
 	if info.Mode()&os.ModeDevice != 0 {
 		//Assume this is zfs device
-		imgInfo, err := zfs.GetZFSVolumeInfo(name)
+		imgInfo, err := zfs.GetZFSVolumeInfo(fileLocation)
 		if err != nil {
 			errStr := fmt.Sprintf("GetVolumeSize/GetZFSInfo failed for %s: %v",
-				name, err)
+				fileLocation, err)
 			return 0, 0, "", false, errors.New(errStr)
 		}
 		return imgInfo.ActualSize, imgInfo.VirtualSize, imgInfo.Format,
 			imgInfo.DirtyFlag, nil
 	}
-	imgInfo, err := diskmetrics.GetImgInfo(log, name)
+	imgInfo, err := diskmetrics.GetImgInfo(log, fileLocation)
 	if err != nil {
 		errStr := fmt.Sprintf("GetVolumeSize/GetImgInfo failed for %s: %v",
-			name, err)
+			fileLocation, err)
 		return 0, 0, "", false, errors.New(errStr)
 	}
 	return imgInfo.ActualSize, imgInfo.VirtualSize, imgInfo.Format,


### PR DESCRIPTION
We iterate over the directory to calculate container's usage which gives
 us wrong numbers if container's rootfs is not mounted (for example if
 container is stopped). Let's use containerd functionality to get usage
 of container properly.

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>