### PR TITLE
Not force build deps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -267,7 +267,8 @@ LINUXKIT_OPTS=$(if $(strip $(EVE_HASH)),--hash) $(EVE_HASH) $(if $(strip $(EVE_R
 LINUXKIT_PKG_TARGET=build
 LINUXKIT_PATCHES_DIR=tools/linuxkit/patches
 RESCAN_DEPS=FORCE
-FORCE_BUILD=--force
+# set FORCE_BUILD to --force to enforce rebuild
+FORCE_BUILD=
 
 # we use the following block to assign correct tag to the Docker registry artifact
 ifeq ($(LINUXKIT_PKG_TARGET),push)
@@ -584,7 +585,6 @@ $(LIVE).parallels: $(LIVE).raw
 
 # top-level linuxkit packages targets, note the one enforcing ordering between packages
 pkgs: RESCAN_DEPS=
-pkgs: FORCE_BUILD=
 pkgs: build-tools $(PKGS)
 	@echo Done building packages
 


### PR DESCRIPTION
Few measurements on my PC (time make pkg/pillar) with changes from PR vs without:

after docker rm -f --volumes linuxkit-builder&&rm -rf ~/.linuxkit: 3m0,280s vs 9m15,422s
with change in go code (just one comment): 1m33,653s vs 2m10,048s
no changes in go code: 0m18,515s vs 0m44,811s