### PR TITLE
Fix check of installed packages in eve-alpine

### DIFF
--- a/pkg/acrn-kernel/Dockerfile
+++ b/pkg/acrn-kernel/Dockerfile
@@ -4,7 +4,7 @@ ENV BUILD_PKGS \
     argp-standalone automake bash bc binutils-dev bison build-base \
     diffutils flex git gmp-dev gnupg installkernel kmod openssl-dev    \
     linux-headers ncurses-dev python3 findutils sed squashfs-tools tar  \
-    xz xz-dev zlib-dev openssl lz4 lz4-libs elfutils-libelf elfutils-dev
+    xz xz-dev zlib-dev openssl lz4 lz4-libs libelf elfutils-dev
 RUN eve-alpine-deploy.sh
 
 

--- a/pkg/alpine/build-cache.sh
+++ b/pkg/alpine/build-cache.sh
@@ -17,7 +17,8 @@ shift 2
 [ ! -d "$CACHE" ] && mkdir -p "$CACHE"
 
 # check for existing packages in the cache: we NEVER overwrite packages
-for p in "$@"; do
+#shellcheck disable=SC2068
+for p in ${@}; do
   [ -f "$(echo "$CACHE/${p}"-[0-9]*)" ] || PKGS="$PKGS $p"
 done
 

--- a/pkg/alpine/mirrors/3.16/main
+++ b/pkg/alpine/mirrors/3.16/main
@@ -15,7 +15,7 @@ bsd-compat-headers
 build-base
 busybox
 ca-certificates
-ca-certificates-cacert
+ca-certificates-bundle
 cairo
 cairo-dev
 cmake
@@ -34,7 +34,6 @@ dtc-dev
 e2fsprogs
 e2fsprogs-extra
 elfutils-dev
-elfutils-libelf
 ethtool
 file
 findutils
@@ -70,6 +69,7 @@ kmod
 kmod-dev
 libaio-dev
 libarchive-tools
+libelf
 libtasn1-progs
 libbz2
 libc-dev
@@ -157,7 +157,7 @@ swig
 tar
 tcpdump
 texinfo
-uboot-tools
+u-boot-tools
 usbutils
 util-linux
 util-linux-dev

--- a/pkg/eve/Dockerfile.in
+++ b/pkg/eve/Dockerfile.in
@@ -1,5 +1,5 @@
 FROM lfedge/eve-alpine:145f062a40639b6c65efa36bed1c5614b873be52 as tools
-ENV PKGS qemu-img tar uboot-tools coreutils dosfstools
+ENV PKGS qemu-img tar u-boot-tools coreutils dosfstools
 RUN eve-alpine-deploy.sh
 
 # hadolint ignore=DL3006

--- a/pkg/xen/Dockerfile
+++ b/pkg/xen/Dockerfile
@@ -4,7 +4,7 @@ ENV BUILD_PKGS argp-standalone automake bash bc binutils-dev bison build-base \
                diffutils flex git gmp-dev gnupg installkernel kmod \
                elfutils-dev openssl-dev linux-headers ncurses-dev python3 \
                sed squashfs-tools tar xz xz-dev zlib-dev libunwind-dev
-ENV BUILD_PKGS_arm64 uboot-tools
+ENV BUILD_PKGS_arm64 u-boot-tools
 RUN eve-alpine-deploy.sh
 
 ENV XEN_UBOOT_ADDR 0x81000000


### PR DESCRIPTION
We want to skip download of packages in cache, but seems we have mistake
 in the loop over installed packages.

Signed-off-by: Petr Fedchenkov <giggsoff@gmail.com>